### PR TITLE
update configure.rb

### DIFF
--- a/cookbooks/postfix/recipes/configure.rb
+++ b/cookbooks/postfix/recipes/configure.rb
@@ -16,7 +16,7 @@ cookbook_file "/etc/opendkim.conf" do
 end
 
 directory "/etc/mail" do
-  owner "nobody"
+  owner "root"
   group "root"
   mode 00755
   recursive true


### PR DESCRIPTION
There is a permission error when running the opendkim start command where the /etc/mail directory isn't owned by root.
